### PR TITLE
fix: type errors in TreeViewComponent and endpoints

### DIFF
--- a/src/components/TreeViewComponent.tsx
+++ b/src/components/TreeViewComponent.tsx
@@ -35,6 +35,11 @@ const TreeViewComponent = ({ defaultOpen, foldersSlug }: TreeViewClientProps) =>
       },
       getItem: (itemId) => {
         // TODO: required to implement but its never used?
+
+        return {
+          relationTo: 'unknown',
+          title: 'Unknown',
+        };
       },
     },
     features: [asyncDataLoaderFeature, selectionFeature],

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -6,6 +6,15 @@ import { addDataAndFileToRequest } from "payload";
 
 import { getIdFromUrl } from "../lib/getIdFromUrl.js";
 
+// TODO: Get doc type from payload
+type Doc = {
+  relationTo: string;
+  value: {
+    id: string;
+    name?: string;
+    title?: string;
+  };
+}
 
 const endpoints: (config: Config, pluginConfig: PayloadFolderTreeViewConfig) => Endpoints = (config, pluginConfig) => ({
   folder: {
@@ -46,7 +55,7 @@ const endpoints: (config: Config, pluginConfig: PayloadFolderTreeViewConfig) => 
         })
       } else {
         data = folders.docs.flatMap((folder) => {
-          return folder.documentsAndFolders.docs.map((doc) => {
+          return folder.documentsAndFolders.docs.map((doc: Doc) => {
             if (doc.relationTo === collection) {
               return {
                 id: doc.value.id,


### PR DESCRIPTION
Address type errors by defining a new `Doc` type and ensuring proper typing in the `TreeViewComponent` and endpoints.

fixes #71 